### PR TITLE
replacing deprecated gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,13 +4,13 @@
 
 'use strict';
 
-var _        = require('lodash');
-var gutil    = require('gulp-util');
-var msg      = require('gulp-messenger');
-var chalk    = require('chalk');
-var utils    = require('./src/utils.js');
-var through  = require('through2');
-var exec     = require('child_process').execFile;
+var _           = require('lodash');
+var PluginError = require('plugin-error');
+var msg         = require('gulp-messenger');
+var chalk       = require('chalk');
+var utils       = require('./src/utils.js');
+var through     = require('through2');
+var exec        = require('child_process').execFile;
 
 msg.init({timestamp: true, logToFile: false});
 
@@ -21,7 +21,7 @@ var phplintPlugin = function(command, opt) {
 
 	if ( typeof command !== 'undefined') {
 		if (typeof command !== 'string') {
-			throw new gutil.PluginError('gulp-phplint', 'Parameter 1 must be path to php command, or empty string');
+			throw new PluginError('gulp-phplint', 'Parameter 1 must be path to php command, or empty string');
 		}
 	}
 

--- a/package.json
+++ b/package.json
@@ -7,11 +7,12 @@
     "chalk": "1.1.3",
     "escape-string-regexp": "1.0.5",
     "exit-code": "1.0.2",
+    "fancy-log": "^1.3.2",
     "gulp-messenger": "0.26.0",
     "gulp-notify": "^2.2.0",
-    "gulp-util": "3.0.8",
     "lodash": "4.17.4",
     "map-stream": "0.0.6",
+    "plugin-error": "0.1.2",
     "through2": "2.0.3"
   },
   "devDependencies": {

--- a/src/reporters/default.js
+++ b/src/reporters/default.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var gutil = require('gulp-util');
-var chalk = require('chalk');
+var fancyLog = require('fancy-log');
+var chalk    = require('chalk');
 
 /**
  * Returns the defalt reporter
@@ -21,7 +21,7 @@ module.exports = function (file) {
         chalk.yellow(report.line) + ' ' + report.message;
     }
 
-    gutil.log(message);
+    fancyLog(message);
   }
 
   return;

--- a/src/reporters/fail.js
+++ b/src/reporters/fail.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var gutil    = require('gulp-util');
 var chalk    = require('chalk');
 var exitcode = require('exit-code');
 

--- a/src/reporters/index.js
+++ b/src/reporters/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var gutil = require('gulp-util');
+var PluginError = require('plugin-error');
 var through = require('through2');
 
 var failReporter = require('./fail');
@@ -26,7 +26,7 @@ module.exports = function (reporter) {
 
   // Check for a valid reporter
   if (typeof reporter !== 'function') {
-    this.emit('error', new gutil.PluginError('gulp-phplint', 'Invalid reporter'));
+    this.emit('error', new PluginError('gulp-phplint', 'Invalid reporter'));
   }
 
   return through.obj(function (file, enc, callback) {


### PR DESCRIPTION
Replace deprecated dependency gulp-util

takes care of https://github.com/mikeerickson/gulp-phplint/issues/39

[`gulp-util`](https://www.npmjs.com/package/gulp-util) has been deprecated recently. Continuing to use this dependency may prevent the use of your library with the recently released version 4 of Gulp, **it is important to replace `gulp-util`**.

The [README.md](https://github.com/gulpjs/gulp-util) lists alternatives for all the components so a simple replacement should be enough.

Your package is popular but still relying on `gulp-util`, it would be good to publish a fixed version to npm as soon as possible.

See:
- https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
- https://github.com/gulpjs/gulp-util/issues/143
  